### PR TITLE
Skip ethereum state tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -67,6 +67,7 @@ jobs:
 
   state:
     name: Ethereum state tests
+    if: false
     runs-on: ubuntu-latest
     env:
       RUST_LOG: info,sync=error


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/op-reth/issues/8.

Skip ef-tests.