### PR TITLE
Revert disable manual workflow run for kurtosis-op and hive

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -3,6 +3,7 @@
 name: hive
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/kurtosis-op.yml
+++ b/.github/workflows/kurtosis-op.yml
@@ -3,6 +3,7 @@
 name: kurtosis-op
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Revert rm `workflow_dispatch` for kurtosis-op and hive

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
