### PR TITLE
fix(docs): revert overwrite pull #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# reth
+# op-reth development lab
+
+## For production op-reth code visit: https://github.com/paradigmxyz/reth
 
 [![CI status](https://github.com/paradigmxyz/reth/workflows/unit/badge.svg)][gh-ci]
 [![cargo-deny status](https://github.com/paradigmxyz/reth/workflows/deny/badge.svg)][gh-deny]


### PR DESCRIPTION
Reverts overwrite of https://github.com/ethereum-optimism/op-reth/pull/24 when pulling upstream changes