### PR TITLE
fix(ci): fix up #32, disable build optimisations for op-reth in kurtosis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,7 @@ unarray.opt-level = 3
 [profile.hivetests]
 inherits = "test"
 lto = "thin"
-opt-level = 1
+opt-level = 0
 
 [profile.release]
 codegen-units = 16


### PR DESCRIPTION
Ref https://github.com/ethereum-optimism/op-reth/pull/32

Disables optimisations for building reth in kurtosis workflow. Decreases time to build op-reth 1-3 minutes.
`opt=1`: https://github.com/ethereum-optimism/op-reth/actions/runs/12932329161/job/36068311065
`opt=0`: https://github.com/ethereum-optimism/op-reth/actions/runs/12932623356/job/36069290126