### PR TITLE
chore: Fix annoying lint warnings

### DIFF
--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -21,7 +21,7 @@ pub struct ExExContext<Node: FullNodeComponents> {
     /// # Important
     ///
     /// The exex should emit a `FinishedHeight` whenever a processed block is safe to prune.
-    /// Additionally, the exex can pre-emptively emit a `FinishedHeight` event to specify what
+    /// Additionally, the exex can preemptively emit a `FinishedHeight` event to specify what
     /// blocks to receive notifications for.
     pub events: UnboundedSender<ExExEvent>,
     /// Channel to receive [`ExExNotification`](crate::ExExNotification)s.

--- a/crates/exex/exex/src/dyn_context.rs
+++ b/crates/exex/exex/src/dyn_context.rs
@@ -26,7 +26,7 @@ pub struct ExExContextDyn<N: NodePrimitives = EthPrimitives> {
     /// # Important
     ///
     /// The exex should emit a `FinishedHeight` whenever a processed block is safe to prune.
-    /// Additionally, the exex can pre-emptively emit a `FinishedHeight` event to specify what
+    /// Additionally, the exex can preemptively emit a `FinishedHeight` event to specify what
     /// blocks to receive notifications for.
     pub events: mpsc::UnboundedSender<ExExEvent>,
     /// Channel to receive [`ExExNotification`](crate::ExExNotification)s.

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -18,7 +18,7 @@ pub trait StateRootProvider: Send + Sync {
     /// computation.
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256>;
 
-    /// Returns the state root of the `HashedPostState` on top of the current state but re-uses the
+    /// Returns the state root of the `HashedPostState` on top of the current state but reuses the
     /// intermediate nodes to speed up the computation. It's up to the caller to construct the
     /// prefix sets and inform the provider of the trie paths that have changes.
     fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256>;

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2341,7 +2341,7 @@ mod tests {
     /// different prefix: 0x0100. Hash builder trie has only the first two leaves, and we have
     /// proofs for them.
     ///
-    /// 1. Insert the leaf 0x0100 into the sparse trie, and check that the root extensino node was
+    /// 1. Insert the leaf 0x0100 into the sparse trie, and check that the root extension node was
     ///    turned into a branch node.
     /// 2. Reveal the leaf 0x0001 in the sparse trie, and check that the root branch node wasn't
     ///    overwritten with the extension node from the proof.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixes several codespell issues that were making pipelines red