### PR TITLE
chore: Restore no-op-geth workflows in the CI

### DIFF
--- a/.github/assets/kurtosis_op_network_params_local_no_op_geth.yaml
+++ b/.github/assets/kurtosis_op_network_params_local_no_op_geth.yaml
@@ -1,0 +1,16 @@
+ethereum_package:
+  participants:
+    - el_type: reth
+      cl_type: lighthouse
+optimism_package:
+  chains:
+    - participants:
+      - el_type: op-reth
+        el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"
+        cl_type: op-node
+        cl_image: "ghcr.io/ethereum-optimism/op-node:kurtosis-ci"
+        cl_extra_params:
+          - "--l1.trustrpc=true"
+      batcher_params:
+        extra_params:
+          - "--throttle-interval=0"

--- a/.github/assets/kurtosis_op_network_params_remote_no_op_geth.yaml
+++ b/.github/assets/kurtosis_op_network_params_remote_no_op_geth.yaml
@@ -1,0 +1,16 @@
+ethereum_package:
+  participants:
+    - el_type: reth
+      cl_type: lighthouse
+optimism_package:
+  chains:
+    - participants:
+      - el_type: op-reth
+        el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"
+        cl_type: op-node
+        cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop
+        cl_extra_params:
+          - "--l1.trustrpc=true"
+      batcher_params:
+        extra_params:
+          - "--throttle-interval=0"

--- a/.github/workflows/kurtosis-op-local.yml
+++ b/.github/workflows/kurtosis-op-local.yml
@@ -66,7 +66,7 @@ jobs:
       cargo_features: optimism,asm-keccak
       cargo_package: crates/optimism/bin/Cargo.toml
 
-  test:
+  test-op-geth:
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -128,9 +128,67 @@ jobs:
           kurtosis service logs -a op-devnet op-cl-2-op-node-op-reth-op-kurtosis
           exit 1
 
+  test-no-op-geth:
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+    name: run kurtosis
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-op-reth
+      - prepare-op-node
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download docker image artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts--*
+          merge-multiple: true
+          path: /tmp
+
+      - name: Load Docker images
+        run: |
+          # Load all images from artifacts
+          docker load -i /tmp/op_reth_image.tar
+          docker load -i /tmp/op_node_image.tar
+          
+          # List available images
+          docker image ls -a
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Run kurtosis
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install kurtosis-cli
+          kurtosis engine start
+          kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params_local_no_op_geth.yaml
+          ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
+          RETH_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-1-op-reth-op-node-op-kurtosis".public_ports.rpc.number')
+          echo "RETH_RPC=http://127.0.0.1:$RETH_PORT" >> $GITHUB_ENV
+
+      - name: Assert that clients advance
+        run: |
+          for i in {1..100}; do
+            sleep 5
+            BLOCK_RETH=$(cast bn --rpc-url $RETH_RPC)
+
+            [ $BLOCK_RETH -ge 100 ] ; then exit 0; fi
+            echo "Waiting for clients to advance..., Reth: $BLOCK_RETH
+          done
+          kurtosis service logs -a op-devnet op-el-1-op-reth-op-node-op-kurtosis
+          kurtosis service logs -a op-devnet op-cl-1-op-node-op-reth-op-kurtosis
+          exit 1
 
   notify-on-error:
-    needs: test
+    needs: 
+      - test-op-geth
+      - test-no-op-geth
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/kurtosis-op-local.yml
+++ b/.github/workflows/kurtosis-op-local.yml
@@ -178,7 +178,7 @@ jobs:
             sleep 5
             BLOCK_RETH=$(cast bn --rpc-url $RETH_RPC)
 
-            [ $BLOCK_RETH -ge 100 ] ; then exit 0; fi
+            if [ $BLOCK_RETH -ge 100 ] ; then exit 0; fi
             echo "Waiting for clients to advance..., Reth: $BLOCK_RETH"
           done
           kurtosis service logs -a op-devnet op-el-1-op-reth-op-node-op-kurtosis

--- a/.github/workflows/kurtosis-op-local.yml
+++ b/.github/workflows/kurtosis-op-local.yml
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-    name: run kurtosis
+    name: Kurtosis with op-geth
     runs-on: ubuntu-latest
     needs:
       - prepare-op-reth
@@ -132,7 +132,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-    name: run kurtosis
+    name: Kurtosis without op-geth
     runs-on: ubuntu-latest
     needs:
       - prepare-op-reth

--- a/.github/workflows/kurtosis-op-local.yml
+++ b/.github/workflows/kurtosis-op-local.yml
@@ -179,7 +179,7 @@ jobs:
             BLOCK_RETH=$(cast bn --rpc-url $RETH_RPC)
 
             [ $BLOCK_RETH -ge 100 ] ; then exit 0; fi
-            echo "Waiting for clients to advance..., Reth: $BLOCK_RETH
+            echo "Waiting for clients to advance..., Reth: $BLOCK_RETH"
           done
           kurtosis service logs -a op-devnet op-el-1-op-reth-op-node-op-kurtosis
           kurtosis service logs -a op-devnet op-cl-1-op-node-op-reth-op-kurtosis

--- a/.github/workflows/kurtosis-op-remote.yml
+++ b/.github/workflows/kurtosis-op-remote.yml
@@ -128,7 +128,7 @@ jobs:
             sleep 5
             BLOCK_RETH=$(cast bn --rpc-url $RETH_RPC)
 
-            [ $BLOCK_RETH -ge 100 ] ; then exit 0; fi
+            if [ $BLOCK_RETH -ge 100 ] ; then exit 0; fi
             echo "Waiting for clients to advance..., Reth: $BLOCK_RETH"
           done
           kurtosis service logs -a op-devnet op-el-1-op-reth-op-node-op-kurtosis

--- a/.github/workflows/kurtosis-op-remote.yml
+++ b/.github/workflows/kurtosis-op-remote.yml
@@ -129,7 +129,7 @@ jobs:
             BLOCK_RETH=$(cast bn --rpc-url $RETH_RPC)
 
             [ $BLOCK_RETH -ge 100 ] ; then exit 0; fi
-            echo "Waiting for clients to advance..., Reth: $BLOCK_RETH
+            echo "Waiting for clients to advance..., Reth: $BLOCK_RETH"
           done
           kurtosis service logs -a op-devnet op-el-1-op-reth-op-node-op-kurtosis
           kurtosis service logs -a op-devnet op-cl-1-op-node-op-reth-op-kurtosis

--- a/.github/workflows/kurtosis-op-remote.yml
+++ b/.github/workflows/kurtosis-op-remote.yml
@@ -22,7 +22,7 @@ jobs:
       cargo_features: optimism,asm-keccak
       cargo_package: crates/optimism/bin/Cargo.toml
 
-  test:
+  test-op-geth:
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -80,9 +80,65 @@ jobs:
           kurtosis service logs -a op-devnet op-cl-2-op-node-op-reth-op-kurtosis
           exit 1
 
+  test-no-op-geth:
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+    name: run kurtosis
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-op-reth
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download docker image artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts--*
+          merge-multiple: true
+          path: /tmp
+
+      - name: Load Docker images
+        run: |
+          # Load all images from artifacts
+          docker load -i /tmp/op_reth_image.tar
+          
+          # List available images
+          docker image ls -a
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Run kurtosis
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install kurtosis-cli
+          kurtosis engine start
+          kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params_remote_no_op_geth.yaml
+          ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
+          RETH_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-1-op-reth-op-node-op-kurtosis".public_ports.rpc.number')
+          echo "RETH_RPC=http://127.0.0.1:$RETH_PORT" >> $GITHUB_ENV
+
+      - name: Assert that clients advance
+        run: |
+          for i in {1..100}; do
+            sleep 5
+            BLOCK_RETH=$(cast bn --rpc-url $RETH_RPC)
+
+            [ $BLOCK_RETH -ge 100 ] ; then exit 0; fi
+            echo "Waiting for clients to advance..., Reth: $BLOCK_RETH
+          done
+          kurtosis service logs -a op-devnet op-el-1-op-reth-op-node-op-kurtosis
+          kurtosis service logs -a op-devnet op-cl-1-op-node-op-reth-op-kurtosis
+          exit 1
 
   notify-on-error:
-    needs: test
+    needs:
+      - test-op-geth
+      - test-no-op-geth
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/kurtosis-op-remote.yml
+++ b/.github/workflows/kurtosis-op-remote.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-    name: run kurtosis
+    name: Kurtosis with op-geth
     runs-on: ubuntu-latest
     needs:
       - prepare-op-reth
@@ -84,7 +84,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-    name: run kurtosis
+    name: Kurtosis without op-geth
     runs-on: ubuntu-latest
     needs:
       - prepare-op-reth


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The kurtosis workflows now run the op-geth/no-op-geth tests in parallel. This PR builds on top of #34 and can be reviewed once that one is merged

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
