### PR TITLE
fix: Fix op-deployer version in kurtosis

### DIFF
--- a/.github/assets/kurtosis_op_network_params_local.yaml
+++ b/.github/assets/kurtosis_op_network_params_local.yaml
@@ -3,6 +3,8 @@ ethereum_package:
     - el_type: reth
       cl_type: lighthouse
 optimism_package:
+  op_contract_deployer_params:
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
   chains:
     - participants:
       - el_type: op-geth

--- a/.github/assets/kurtosis_op_network_params_local_no_op_geth.yaml
+++ b/.github/assets/kurtosis_op_network_params_local_no_op_geth.yaml
@@ -3,6 +3,8 @@ ethereum_package:
     - el_type: reth
       cl_type: lighthouse
 optimism_package:
+  op_contract_deployer_params:
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
   chains:
     - participants:
       - el_type: op-reth

--- a/.github/assets/kurtosis_op_network_params_remote.yaml
+++ b/.github/assets/kurtosis_op_network_params_remote.yaml
@@ -3,6 +3,8 @@ ethereum_package:
     - el_type: reth
       cl_type: lighthouse
 optimism_package:
+  op_contract_deployer_params:
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
   chains:
     - participants:
       - el_type: op-geth
@@ -12,7 +14,7 @@ optimism_package:
         cl_extra_params:
           - "--l1.trustrpc=true"
       - el_type: op-reth
-        el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"
+        el_image: "op-reth:latest"
         cl_type: op-node
         cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop
         cl_extra_params:

--- a/.github/assets/kurtosis_op_network_params_remote_no_op_geth.yaml
+++ b/.github/assets/kurtosis_op_network_params_remote_no_op_geth.yaml
@@ -3,6 +3,8 @@ ethereum_package:
     - el_type: reth
       cl_type: lighthouse
 optimism_package:
+  op_contract_deployer_params:
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
   chains:
     - participants:
       - el_type: op-reth


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- The `op-deployer` version in kurtosis args files needs to be updated, otherwise the isthmus config is not being respected

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
