### PR TITLE
chore: Remove op-deployer version override in kurtosis after a package update

### DIFF
--- a/.github/assets/kurtosis_op_network_params_local.yaml
+++ b/.github/assets/kurtosis_op_network_params_local.yaml
@@ -3,8 +3,6 @@ ethereum_package:
     - el_type: reth
       cl_type: lighthouse
 optimism_package:
-  op_contract_deployer_params:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
   chains:
     - participants:
       - el_type: op-geth

--- a/.github/assets/kurtosis_op_network_params_local_no_op_geth.yaml
+++ b/.github/assets/kurtosis_op_network_params_local_no_op_geth.yaml
@@ -3,8 +3,6 @@ ethereum_package:
     - el_type: reth
       cl_type: lighthouse
 optimism_package:
-  op_contract_deployer_params:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
   chains:
     - participants:
       - el_type: op-reth

--- a/.github/assets/kurtosis_op_network_params_remote.yaml
+++ b/.github/assets/kurtosis_op_network_params_remote.yaml
@@ -3,8 +3,6 @@ ethereum_package:
     - el_type: reth
       cl_type: lighthouse
 optimism_package:
-  op_contract_deployer_params:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
   chains:
     - participants:
       - el_type: op-geth

--- a/.github/assets/kurtosis_op_network_params_remote_no_op_geth.yaml
+++ b/.github/assets/kurtosis_op_network_params_remote_no_op_geth.yaml
@@ -3,8 +3,6 @@ ethereum_package:
     - el_type: reth
       cl_type: lighthouse
 optimism_package:
-  op_contract_deployer_params:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11
   chains:
     - participants:
       - el_type: op-reth


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The `op-deployer` image version can now be removed since the [`optimism-package` default value update has been merged](https://github.com/ethpandaops/optimism-package/pull/146)