### PR TITLE
fix(optimism): Node Tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8649,6 +8649,7 @@ dependencies = [
  "reth-errors",
  "reth-exex-types",
  "reth-metrics",
+ "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2821,7 +2821,7 @@ mod tests {
     use reth_ethereum_consensus::EthBeaconConsensus;
     use reth_ethereum_engine_primitives::{EthEngineTypes, EthereumEngineValidator};
     use reth_evm::test_utils::MockExecutorProvider;
-    use reth_primitives::{Block, EthPrimitives};
+    use reth_primitives::{Block, EthPrimitives, TransactionSigned};
     use reth_primitives_traits::Block as _;
     use reth_provider::test_utils::MockEthProvider;
     use reth_rpc_types_compat::engine::{block_to_payload_v1, payload::block_to_payload_v3};
@@ -2924,7 +2924,7 @@ mod tests {
 
             let consensus = Arc::new(EthBeaconConsensus::new(chain_spec.clone()));
 
-            let provider = MockEthProvider::default();
+            let provider = MockEthProvider::<TransactionSigned>::default();
             let executor_provider = MockExecutorProvider::default();
 
             let payload_validator = EthereumEngineValidator::new(chain_spec.clone());

--- a/crates/net/network/benches/broadcast.rs
+++ b/crates/net/network/benches/broadcast.rs
@@ -31,7 +31,8 @@ pub fn broadcast_ingress_bench(c: &mut Criterion) {
                 // runtime context and simply calling `block_on` here will cause the code to panic.
                 tokio::task::block_in_place(|| {
                     tokio::runtime::Handle::current().block_on(async {
-                        let provider = MockEthProvider::default();
+                        use reth_primitives::TransactionSigned;
+                        let provider = MockEthProvider::<TransactionSigned>::default();
                         let mut net = Testnet::create_with(2, provider.clone()).await;
 
                         let mut peer0 = net.remove_peer(0);

--- a/crates/net/network/benches/tx_manager_hash_fetching.rs
+++ b/crates/net/network/benches/tx_manager_hash_fetching.rs
@@ -42,7 +42,8 @@ pub fn tx_fetch_bench(c: &mut Criterion) {
                             ..Default::default()
                         };
 
-                        let provider = MockEthProvider::default();
+                        use reth_primitives::TransactionSigned;
+                        let provider = MockEthProvider::<TransactionSigned>::default();
                         let num_peers = 10;
                         let net = Testnet::create_with(num_peers, provider.clone()).await;
 

--- a/crates/net/network/tests/it/big_pooled_txs_req.rs
+++ b/crates/net/network/tests/it/big_pooled_txs_req.rs
@@ -36,7 +36,7 @@ async fn test_large_tx_req() {
     let txs_hashes: Vec<B256> = txs.iter().map(|tx| *tx.get_hash()).collect();
 
     // setup testnet
-    let mut net = Testnet::create_with(2, MockEthProvider::default()).await;
+    let mut net = Testnet::create_with(2, MockEthProvider::<TransactionSigned>::default()).await;
 
     // install request handlers
     net.for_each_mut(|peer| peer.install_request_handler());

--- a/crates/net/network/tests/it/multiplex.rs
+++ b/crates/net/network/tests/it/multiplex.rs
@@ -278,7 +278,8 @@ impl Stream for PingPongProtoConnection {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_proto_multiplex() {
     reth_tracing::init_test_tracing();
-    let provider = MockEthProvider::default();
+    use reth_primitives::TransactionSigned;
+    let provider = MockEthProvider::<TransactionSigned>::default();
     let mut net = Testnet::create_with(2, provider.clone()).await;
 
     let (tx, mut from_peer0) = mpsc::unbounded_channel();

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -40,7 +40,7 @@ pub fn rng_transaction(rng: &mut impl rand::RngCore) -> TransactionSigned {
 async fn test_get_body() {
     reth_tracing::init_test_tracing();
     let mut rng = rand::thread_rng();
-    let mock_provider = Arc::new(MockEthProvider::default());
+    let mock_provider = Arc::new(MockEthProvider::<TransactionSigned>::default());
 
     let mut net = Testnet::create_with(2, mock_provider.clone()).await;
 
@@ -82,7 +82,7 @@ async fn test_get_body() {
 async fn test_get_header() {
     reth_tracing::init_test_tracing();
     let mut rng = rand::thread_rng();
-    let mock_provider = Arc::new(MockEthProvider::default());
+    let mock_provider = Arc::new(MockEthProvider::<TransactionSigned>::default());
 
     let mut net = Testnet::create_with(2, mock_provider.clone()).await;
 

--- a/crates/net/network/tests/it/transaction_hash_fetching.rs
+++ b/crates/net/network/tests/it/transaction_hash_fetching.rs
@@ -17,7 +17,8 @@ async fn transaction_hash_fetching() {
     let mut config = TransactionsManagerConfig { propagation_mode: Max(0), ..Default::default() };
     config.transaction_fetcher_config.max_inflight_requests = 1;
 
-    let provider = MockEthProvider::default();
+    use reth_primitives::TransactionSigned;
+    let provider = MockEthProvider::<TransactionSigned>::default();
     let num_peers = 10;
     let net = Testnet::create_with(num_peers, provider.clone()).await;
 

--- a/crates/net/network/tests/it/txgossip.rs
+++ b/crates/net/network/tests/it/txgossip.rs
@@ -17,7 +17,7 @@ use reth_transaction_pool::{test_utils::TransactionGenerator, PoolTransaction, T
 async fn test_tx_gossip() {
     reth_tracing::init_test_tracing();
 
-    let provider = MockEthProvider::default();
+    let provider = MockEthProvider::<TransactionSigned>::default();
     let net = Testnet::create_with(2, provider.clone()).await;
 
     // install request handlers
@@ -54,7 +54,7 @@ async fn test_tx_gossip() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_4844_tx_gossip_penalization() {
     reth_tracing::init_test_tracing();
-    let provider = MockEthProvider::default();
+    let provider = MockEthProvider::<TransactionSigned>::default();
     let net = Testnet::create_with(2, provider.clone()).await;
 
     // install request handlers
@@ -105,7 +105,7 @@ async fn test_4844_tx_gossip_penalization() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sending_invalid_transactions() {
     reth_tracing::init_test_tracing();
-    let provider = MockEthProvider::default();
+    let provider = MockEthProvider::<TransactionSigned>::default();
     let net = Testnet::create_with(2, provider.clone()).await;
     // install request handlers
     let net = net.with_eth_pool();

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -542,8 +542,8 @@ mod tests {
     use reth_primitives::Recovered;
     use reth_provider::test_utils::MockEthProvider;
     use reth_transaction_pool::{
-        blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder,
-         TransactionOrigin, TransactionValidationOutcome,
+        blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder, TransactionOrigin,
+        TransactionValidationOutcome,
     };
 
     #[test]

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -531,54 +531,53 @@ pub struct OpL1BlockInfo {
     timestamp: AtomicU64,
 }
 
-// TODO(refcell): fix this in a follow on PR
-// #[cfg(test)]
-// mod tests {
-//     use crate::txpool::{OpPooledTransaction, OpTransactionValidator};
-//     use alloy_eips::eip2718::Encodable2718;
-//     use alloy_primitives::{PrimitiveSignature as Signature, TxKind, U256};
-//     use op_alloy_consensus::{OpTypedTransaction, TxDeposit};
-//     use reth_chainspec::MAINNET;
-//     use reth_optimism_primitives::OpTransactionSigned;
-//     use reth_primitives::Recovered;
-//     use reth_provider::test_utils::MockEthProvider;
-//     use reth_transaction_pool::{
-//         blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder,
-//          TransactionOrigin, TransactionValidationOutcome,
-//     };
-//
-//     #[test]
-//     fn validate_optimism_transaction() {
-//         let client: MockEthProvider<OpTransactionSigned> = MockEthProvider::default();
-//         let validator = EthTransactionValidatorBuilder::new(MAINNET.clone())
-//             .no_shanghai()
-//             .no_cancun()
-//             .build(client, InMemoryBlobStore::default());
-//         let validator = OpTransactionValidator::new(validator);
-//
-//         let origin = TransactionOrigin::External;
-//         let signer = Default::default();
-//         let deposit_tx = OpTypedTransaction::Deposit(TxDeposit {
-//             source_hash: Default::default(),
-//             from: signer,
-//             to: TxKind::Create,
-//             mint: None,
-//             value: U256::ZERO,
-//             gas_limit: 0,
-//             is_system_transaction: false,
-//             input: Default::default(),
-//         });
-//         let signature = Signature::test_signature();
-//         let signed_tx = OpTransactionSigned::new_unhashed(deposit_tx, signature);
-//         let signed_recovered = Recovered::new_unchecked(signed_tx, signer);
-//         let len = signed_recovered.encode_2718_len();
-//         let pooled_tx = OpPooledTransaction::new(signed_recovered, len);
-//         let outcome = validator.validate_one(origin, pooled_tx);
-//
-//         let err = match outcome {
-//             TransactionValidationOutcome::Invalid(_, err) => err,
-//             _ => panic!("Expected invalid transaction"),
-//         };
-//         assert_eq!(err.to_string(), "transaction type not supported");
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use crate::txpool::{OpPooledTransaction, OpTransactionValidator};
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::{PrimitiveSignature as Signature, TxKind, U256};
+    use op_alloy_consensus::{OpTypedTransaction, TxDeposit};
+    use reth_chainspec::MAINNET;
+    use reth_optimism_primitives::OpTransactionSigned;
+    use reth_primitives::Recovered;
+    use reth_provider::test_utils::MockEthProvider;
+    use reth_transaction_pool::{
+        blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder,
+         TransactionOrigin, TransactionValidationOutcome,
+    };
+
+    #[test]
+    fn validate_optimism_transaction() {
+        let client: MockEthProvider<OpTransactionSigned> = MockEthProvider::default();
+        let validator = EthTransactionValidatorBuilder::new(MAINNET.clone())
+            .no_shanghai()
+            .no_cancun()
+            .build(client, InMemoryBlobStore::default());
+        let validator = OpTransactionValidator::new(validator);
+
+        let origin = TransactionOrigin::External;
+        let signer = Default::default();
+        let deposit_tx = OpTypedTransaction::Deposit(TxDeposit {
+            source_hash: Default::default(),
+            from: signer,
+            to: TxKind::Create,
+            mint: None,
+            value: U256::ZERO,
+            gas_limit: 0,
+            is_system_transaction: false,
+            input: Default::default(),
+        });
+        let signature = Signature::test_signature();
+        let signed_tx = OpTransactionSigned::new_unhashed(deposit_tx, signature);
+        let signed_recovered = Recovered::new_unchecked(signed_tx, signer);
+        let len = signed_recovered.encode_2718_len();
+        let pooled_tx = OpPooledTransaction::new(signed_recovered, len);
+        let outcome = validator.validate_one(origin, pooled_tx);
+
+        let err = match outcome {
+            TransactionValidationOutcome::Invalid(_, err) => err,
+            _ => panic!("Expected invalid transaction"),
+        };
+        assert_eq!(err.to_string(), "transaction type not supported");
+    }
+}

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -548,7 +548,7 @@ mod tests {
 
     #[test]
     fn validate_optimism_transaction() {
-        let client: MockEthProvider<OpTransactionSigned> = MockEthProvider::default();
+        let client = MockEthProvider::<OpTransactionSigned>::default();
         let validator = EthTransactionValidatorBuilder::new(MAINNET.clone())
             .no_shanghai()
             .no_cancun()

--- a/crates/prune/prune/Cargo.toml
+++ b/crates/prune/prune/Cargo.toml
@@ -49,5 +49,6 @@ reth-stages = { workspace = true, features = ["test-utils"] }
 reth-primitives-traits = { workspace = true, features = ["arbitrary"] }
 reth-testing-utils.workspace = true
 reth-tracing.workspace = true
+reth-primitives.workspace = true
 
 assert_matches.workspace = true

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -150,6 +150,7 @@ mod tests {
         providers::BlockchainProvider,
         test_utils::{create_test_provider_factory, MockEthProvider},
     };
+    use reth_primitives::TransactionSigned;
     use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
 
     #[test]
@@ -161,7 +162,7 @@ mod tests {
         };
 
         // Default provider with no block corresponding to block 10
-        let provider = MockEthProvider::default();
+        let provider: MockEthProvider<TransactionSigned> = MockEthProvider::default();
 
         // No block body for block 10, expected None
         let range = input.get_next_tx_num_range(&provider).expect("Expected range");

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -146,11 +146,11 @@ impl PruneInput {
 mod tests {
     use super::*;
     use alloy_primitives::B256;
+    use reth_primitives::TransactionSigned;
     use reth_provider::{
         providers::BlockchainProvider,
         test_utils::{create_test_provider_factory, MockEthProvider},
     };
-    use reth_primitives::TransactionSigned;
     use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
 
     #[test]

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -162,7 +162,7 @@ mod tests {
         };
 
         // Default provider with no block corresponding to block 10
-        let provider: MockEthProvider<TransactionSigned> = MockEthProvider::default();
+        let provider = MockEthProvider::<TransactionSigned>::default();
 
         // No block body for block 10, expected None
         let range = input.get_next_tx_num_range(&provider).expect("Expected range");

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1053,7 +1053,7 @@ mod tests {
         };
 
         let chain_spec: Arc<ChainSpec> = MAINNET.clone();
-        let provider = Arc::new(MockEthProvider::default());
+        let provider = Arc::new(MockEthProvider::<TransactionSigned>::default());
         let payload_store = spawn_test_payload_service();
         let (to_engine, engine_rx) = unbounded_channel();
         let task_executor = Box::<TokioTaskExecutor>::default();

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -620,8 +620,7 @@ mod tests {
         let oldest_block = None;
 
         let provider = MockEthProvider::<TransactionSigned>::default();
-        let (eth_api, _, _) =
-            prepare_eth_api(newest_block, oldest_block, block_count, provider);
+        let (eth_api, _, _) = prepare_eth_api(newest_block, oldest_block, block_count, provider);
 
         let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
             &eth_api,
@@ -644,8 +643,7 @@ mod tests {
         let oldest_block = None;
 
         let provider = MockEthProvider::<TransactionSigned>::default();
-        let (eth_api, _, _) =
-            prepare_eth_api(newest_block, oldest_block, block_count, provider);
+        let (eth_api, _, _) = prepare_eth_api(newest_block, oldest_block, block_count, provider);
 
         let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
             &eth_api,
@@ -668,8 +666,7 @@ mod tests {
         let oldest_block = None;
 
         let provider = MockEthProvider::<TransactionSigned>::default();
-        let (eth_api, _, _) =
-            prepare_eth_api(newest_block, oldest_block, block_count, provider);
+        let (eth_api, _, _) = prepare_eth_api(newest_block, oldest_block, block_count, provider);
 
         let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
             &eth_api,

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -619,8 +619,9 @@ mod tests {
         let newest_block = 1337;
         let oldest_block = None;
 
+        let provider = MockEthProvider::<TransactionSigned>::default();
         let (eth_api, _, _) =
-            prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
+            prepare_eth_api(newest_block, oldest_block, block_count, provider);
 
         let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
             &eth_api,
@@ -642,8 +643,9 @@ mod tests {
         let newest_block = 1337;
         let oldest_block = None;
 
+        let provider = MockEthProvider::<TransactionSigned>::default();
         let (eth_api, _, _) =
-            prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
+            prepare_eth_api(newest_block, oldest_block, block_count, provider);
 
         let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
             &eth_api,
@@ -665,8 +667,9 @@ mod tests {
         let newest_block = 1337;
         let oldest_block = None;
 
+        let provider = MockEthProvider::<TransactionSigned>::default();
         let (eth_api, _, _) =
-            prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
+            prepare_eth_api(newest_block, oldest_block, block_count, provider);
 
         let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
             &eth_api,
@@ -690,8 +693,9 @@ mod tests {
         let newest_block = 1337;
         let oldest_block = None;
 
+        let provider = MockEthProvider::<TransactionSigned>::default();
         let (eth_api, base_fees_per_gas, gas_used_ratios) =
-            prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
+            prepare_eth_api(newest_block, oldest_block, block_count, provider);
 
         let fee_history =
             eth_api.fee_history(U64::from(1), newest_block.into(), None).await.unwrap();
@@ -724,8 +728,9 @@ mod tests {
         let newest_block = 1337;
         let oldest_block = None;
 
+        let provider = MockEthProvider::<TransactionSigned>::default();
         let (eth_api, base_fees_per_gas, gas_used_ratios) =
-            prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
+            prepare_eth_api(newest_block, oldest_block, block_count, provider);
 
         let fee_history =
             eth_api.fee_history(U64::from(block_count), newest_block.into(), None).await.unwrap();

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -78,7 +78,8 @@ mod tests {
         accounts: HashMap<Address, ExtendedAccount>,
     ) -> EthApi<MockEthProvider, TestPool, (), EthEvmConfig> {
         let pool = testing_pool();
-        let mock_provider = MockEthProvider::default();
+        use reth_primitives::TransactionSigned;
+        let mock_provider = MockEthProvider::<TransactionSigned>::default();
 
         let evm_config = EthEvmConfig::new(mock_provider.chain_spec());
         mock_provider.extend_accounts(accounts);

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -258,7 +258,6 @@ impl HeaderProvider for MockEthProvider<reth_optimism_primitives::OpTransactionS
     }
 }
 
-
 impl HeaderProvider for MockEthProvider {
     type Header = Header;
 
@@ -807,7 +806,6 @@ impl BlockIdReader for MockEthProvider<reth_optimism_primitives::OpTransactionSi
     }
 }
 
-
 impl BlockReader for MockEthProvider {
     type Block = Block;
 
@@ -906,11 +904,9 @@ impl BlockReader for MockEthProvider<reth_optimism_primitives::OpTransactionSign
         Ok(None)
     }
 
-    fn pending_block_with_senders(
-        &self,
-    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
-        Ok(None)
-    }
+    fn pending_block_with_senders(&self) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+         Ok(None)
+     }
 
     fn pending_block_and_receipts(&self) -> ProviderResult<Option<(reth_primitives_traits::block::SealedBlock<Self::Block>, Vec<Receipt>)>> {
         Ok(None)

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -164,6 +164,26 @@ impl StateCommitmentProvider for MockEthProvider {
     type StateCommitment = <MockNode as NodeTypes>::StateCommitment;
 }
 
+#[cfg(feature = "optimism")]
+impl StateCommitmentProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    type StateCommitment = <MockNode as NodeTypes>::StateCommitment;
+}
+
+#[cfg(feature = "optimism")]
+impl DatabaseProviderFactory for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    type DB = DatabaseMock;
+    type Provider = DatabaseProvider<TxMock, MockNode>;
+    type ProviderRW = DatabaseProvider<TxMock, MockNode>;
+
+    fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
+        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
+    }
+
+    fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
+        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
+    }
+}
+
 impl DatabaseProviderFactory for MockEthProvider {
     type DB = DatabaseMock;
     type Provider = DatabaseProvider<TxMock, MockNode>;
@@ -177,6 +197,67 @@ impl DatabaseProviderFactory for MockEthProvider {
         Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
     }
 }
+
+#[cfg(feature = "optimism")]
+impl HeaderProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    type Header = Header;
+
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
+        let lock = self.headers.lock();
+        Ok(lock.get(block_hash).cloned())
+    }
+
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
+        let lock = self.headers.lock();
+        Ok(lock.values().find(|h| h.number == num).cloned())
+    }
+
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        let lock = self.headers.lock();
+        Ok(lock.get(hash).map(|target| {
+            lock.values()
+                .filter(|h| h.number < target.number)
+                .fold(target.difficulty, |td, h| td + h.difficulty)
+        }))
+    }
+
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
+        let lock = self.headers.lock();
+        let sum = lock
+            .values()
+            .filter(|h| h.number <= number)
+            .fold(U256::ZERO, |td, h| td + h.difficulty);
+        Ok(Some(sum))
+    }
+
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
+        let lock = self.headers.lock();
+
+        let mut headers: Vec<_> =
+            lock.values().filter(|header| range.contains(&header.number)).cloned().collect();
+        headers.sort_by_key(|header| header.number);
+
+        Ok(headers)
+    }
+
+    fn sealed_header(&self, number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
+        Ok(self.header_by_number(number)?.map(SealedHeader::seal_slow))
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        mut predicate: impl FnMut(&SealedHeader) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader>> {
+        Ok(self
+            .headers_range(range)?
+            .into_iter()
+            .map(SealedHeader::seal_slow)
+            .take_while(|h| predicate(h))
+            .collect())
+    }
+}
+
 
 impl HeaderProvider for MockEthProvider {
     type Header = Header;
@@ -237,11 +318,160 @@ impl HeaderProvider for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl ChainSpecProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    type ChainSpec = ChainSpec;
+
+    fn chain_spec(&self) -> Arc<ChainSpec> {
+        self.chain_spec.clone()
+    }
+}
+
 impl ChainSpecProvider for MockEthProvider {
     type ChainSpec = ChainSpec;
 
     fn chain_spec(&self) -> Arc<ChainSpec> {
         self.chain_spec.clone()
+    }
+}
+
+#[cfg(feature = "optimism")]
+impl TransactionsProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    type Transaction = reth_optimism_primitives::OpTransactionSigned;
+
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
+        let lock = self.blocks.lock();
+        let tx_number = lock
+            .values()
+            .flat_map(|block| &block.body.transactions)
+            .position(|tx| *tx.tx_hash() == tx_hash)
+            .map(|pos| pos as TxNumber);
+
+        Ok(tx_number)
+    }
+
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+        let lock = self.blocks.lock();
+        let transaction =
+            lock.values().flat_map(|block| &block.body.transactions).nth(id as usize).cloned();
+
+        Ok(transaction)
+    }
+
+    fn transaction_by_id_unhashed(
+        &self,
+        id: TxNumber,
+    ) -> ProviderResult<Option<Self::Transaction>> {
+        let lock = self.blocks.lock();
+        let transaction =
+            lock.values().flat_map(|block| &block.body.transactions).nth(id as usize).cloned();
+
+        Ok(transaction)
+    }
+
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+        Ok(self.blocks.lock().iter().find_map(|(_, block)| {
+            block.body.transactions.iter().find(|tx| *tx.tx_hash() == hash).cloned()
+        }))
+    }
+
+    fn transaction_by_hash_with_meta(
+        &self,
+        hash: TxHash,
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+        let lock = self.blocks.lock();
+        for (block_hash, block) in lock.iter() {
+            for (index, tx) in block.body.transactions.iter().enumerate() {
+                if *tx.tx_hash() == hash {
+                    let meta = TransactionMeta {
+                        tx_hash: hash,
+                        index: index as u64,
+                        block_hash: *block_hash,
+                        block_number: block.header.number,
+                        base_fee: block.header.base_fee_per_gas,
+                        excess_blob_gas: block.header.excess_blob_gas,
+                        timestamp: block.header.timestamp,
+                    };
+                    return Ok(Some((tx.clone(), meta)))
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn transaction_block(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
+        let lock = self.blocks.lock();
+        let mut current_tx_number: TxNumber = 0;
+        for block in lock.values() {
+            if current_tx_number + (block.body.transactions.len() as TxNumber) > id {
+                return Ok(Some(block.header.number))
+            }
+            current_tx_number += block.body.transactions.len() as TxNumber;
+        }
+        Ok(None)
+    }
+
+    fn transactions_by_block(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+        Ok(self.block(id)?.map(|b| b.body.transactions))
+    }
+
+    fn transactions_by_block_range(
+        &self,
+        range: impl RangeBounds<alloy_primitives::BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+        // init btreemap so we can return in order
+        let mut map = BTreeMap::new();
+        for (_, block) in self.blocks.lock().iter() {
+            if range.contains(&block.number) {
+                map.insert(block.number, block.body.transactions.clone());
+            }
+        }
+
+        Ok(map.into_values().collect())
+    }
+
+    fn transactions_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Self::Transaction>> {
+        let lock = self.blocks.lock();
+        let transactions = lock
+            .values()
+            .flat_map(|block| &block.body.transactions)
+            .enumerate()
+            .filter(|&(tx_number, _)| range.contains(&(tx_number as TxNumber)))
+            .map(|(_, tx)| tx.clone())
+            .collect();
+
+        Ok(transactions)
+    }
+
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
+        let lock = self.blocks.lock();
+        let transactions = lock
+            .values()
+            .flat_map(|block| &block.body.transactions)
+            .enumerate()
+            .filter_map(|(tx_number, tx)| {
+                if range.contains(&(tx_number as TxNumber)) {
+                    tx.recover_signer().ok()
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        Ok(transactions)
+    }
+
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
+        self.transaction_by_id(id).map(|tx_option| tx_option.map(|tx| tx.recover_signer().unwrap()))
     }
 }
 
@@ -384,6 +614,30 @@ impl TransactionsProvider for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl ReceiptProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    type Receipt = Receipt;
+
+    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
+        Ok(None)
+    }
+
+    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Receipt>> {
+        Ok(None)
+    }
+
+    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+        Ok(None)
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        _range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        Ok(vec![])
+    }
+}
+
 impl ReceiptProvider for MockEthProvider {
     type Receipt = Receipt;
 
@@ -409,7 +663,35 @@ impl ReceiptProvider for MockEthProvider {
 
 impl ReceiptProviderIdExt for MockEthProvider {}
 
+#[cfg(feature = "optimism")]
+impl ReceiptProviderIdExt for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {}
+
 impl BlockHashReader for MockEthProvider {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        let lock = self.blocks.lock();
+
+        let hash = lock.iter().find_map(|(hash, b)| (b.number == number).then_some(*hash));
+        Ok(hash)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        let range = start..end;
+        let lock = self.blocks.lock();
+
+        let mut hashes: Vec<_> =
+            lock.iter().filter(|(_, block)| range.contains(&block.number)).collect();
+        hashes.sort_by_key(|(_, block)| block.number);
+
+        Ok(hashes.into_iter().map(|(hash, _)| *hash).collect())
+    }
+}
+
+#[cfg(feature = "optimism")]
+impl BlockHashReader for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         let lock = self.blocks.lock();
 
@@ -464,6 +746,38 @@ impl BlockNumReader for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl BlockNumReader for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        let best_block_number = self.best_block_number()?;
+        let lock = self.headers.lock();
+
+        Ok(lock
+            .iter()
+            .find(|(_, header)| header.number == best_block_number)
+            .map(|(hash, header)| ChainInfo { best_hash: *hash, best_number: header.number })
+            .unwrap_or_default())
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        let lock = self.headers.lock();
+        lock.iter()
+            .max_by_key(|h| h.1.number)
+            .map(|(_, header)| header.number)
+            .ok_or(ProviderError::BestBlockNotFound)
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.best_block_number()
+    }
+
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<alloy_primitives::BlockNumber>> {
+        let lock = self.blocks.lock();
+        let num = lock.iter().find_map(|(h, b)| (*h == hash).then_some(b.number));
+        Ok(num)
+    }
+}
+
 impl BlockIdReader for MockEthProvider {
     fn pending_block_num_hash(&self) -> ProviderResult<Option<alloy_eips::BlockNumHash>> {
         Ok(None)
@@ -477,6 +791,22 @@ impl BlockIdReader for MockEthProvider {
         Ok(None)
     }
 }
+
+#[cfg(feature = "optimism")]
+impl BlockIdReader for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn pending_block_num_hash(&self) -> ProviderResult<Option<alloy_eips::BlockNumHash>> {
+        Ok(None)
+    }
+
+    fn safe_block_num_hash(&self) -> ProviderResult<Option<alloy_eips::BlockNumHash>> {
+        Ok(None)
+    }
+
+    fn finalized_block_num_hash(&self) -> ProviderResult<Option<alloy_eips::BlockNumHash>> {
+        Ok(None)
+    }
+}
+
 
 impl BlockReader for MockEthProvider {
     type Block = Block;
@@ -552,8 +882,112 @@ impl BlockReader for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl BlockReader for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    type Block = alloy_consensus::Block<reth_optimism_primitives::OpTransactionSigned>;
+
+    fn find_block_by_hash(
+        &self,
+        hash: B256,
+        _source: BlockSource,
+    ) -> ProviderResult<Option<Self::Block>> {
+        self.block(hash.into())
+    }
+
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Self::Block>> {
+        let lock = self.blocks.lock();
+        match id {
+            BlockHashOrNumber::Hash(hash) => Ok(lock.get(&hash).cloned()),
+            BlockHashOrNumber::Number(num) => Ok(lock.values().find(|b| b.number == num).cloned()),
+        }
+    }
+
+    fn pending_block(&self) -> ProviderResult<Option<reth_primitives_traits::block::SealedBlock<Self::Block>>> {
+        Ok(None)
+    }
+
+    fn pending_block_with_senders(
+        &self,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        Ok(None)
+    }
+
+    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(reth_primitives_traits::block::SealedBlock<Self::Block>, Vec<Receipt>)>> {
+        Ok(None)
+    }
+
+    fn block_with_senders(
+        &self,
+        _id: BlockHashOrNumber,
+        _transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        Ok(None)
+    }
+
+    fn sealed_block_with_senders(
+        &self,
+        _id: BlockHashOrNumber,
+        _transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+        Ok(None)
+    }
+
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
+        let lock = self.blocks.lock();
+
+        let mut blocks: Vec<_> =
+            lock.values().filter(|block| range.contains(&block.number)).cloned().collect();
+        blocks.sort_by_key(|block| block.number);
+
+        Ok(blocks)
+    }
+
+    fn block_with_senders_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        Ok(vec![])
+    }
+
+    fn sealed_block_with_senders_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+        Ok(vec![])
+    }
+}
+
+
 impl BlockReaderIdExt for MockEthProvider {
     fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Block>> {
+        match id {
+            BlockId::Number(num) => self.block_by_number_or_tag(num),
+            BlockId::Hash(hash) => self.block_by_hash(hash.block_hash),
+        }
+    }
+
+    fn sealed_header_by_id(&self, id: BlockId) -> ProviderResult<Option<SealedHeader>> {
+        self.header_by_id(id)?.map_or_else(|| Ok(None), |h| Ok(Some(SealedHeader::seal_slow(h))))
+    }
+
+    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<Header>> {
+        match self.block_by_id(id)? {
+            None => Ok(None),
+            Some(block) => Ok(Some(block.header)),
+        }
+    }
+
+    fn ommers_by_id(&self, id: BlockId) -> ProviderResult<Option<Vec<Header>>> {
+        match id {
+            BlockId::Number(num) => self.ommers_by_number_or_tag(num),
+            BlockId::Hash(hash) => self.ommers(BlockHashOrNumber::Hash(hash.block_hash)),
+        }
+    }
+}
+
+#[cfg(feature = "optimism")]
+impl BlockReaderIdExt for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<alloy_consensus::Block<reth_optimism_primitives::OpTransactionSigned>>> {
         match id {
             BlockId::Number(num) => self.block_by_number_or_tag(num),
             BlockId::Hash(hash) => self.block_by_hash(hash.block_hash),
@@ -585,6 +1019,14 @@ impl AccountReader for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl AccountReader for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        Ok(self.accounts.lock().get(address).cloned().map(|a| a.account))
+    }
+}
+
+
 impl StageCheckpointReader for MockEthProvider {
     fn get_stage_checkpoint(&self, _id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
         Ok(None)
@@ -599,7 +1041,50 @@ impl StageCheckpointReader for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl StageCheckpointReader for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn get_stage_checkpoint(&self, _id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
+        Ok(None)
+    }
+
+    fn get_stage_checkpoint_progress(&self, _id: StageId) -> ProviderResult<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    fn get_all_checkpoints(&self) -> ProviderResult<Vec<(String, StageCheckpoint)>> {
+        Ok(vec![])
+    }
+}
+
+
 impl StateRootProvider for MockEthProvider {
+    fn state_root(&self, _state: HashedPostState) -> ProviderResult<B256> {
+        Ok(self.state_roots.lock().pop().unwrap_or_default())
+    }
+
+    fn state_root_from_nodes(&self, _input: TrieInput) -> ProviderResult<B256> {
+        Ok(self.state_roots.lock().pop().unwrap_or_default())
+    }
+
+    fn state_root_with_updates(
+        &self,
+        _state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let state_root = self.state_roots.lock().pop().unwrap_or_default();
+        Ok((state_root, Default::default()))
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        _input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let state_root = self.state_roots.lock().pop().unwrap_or_default();
+        Ok((state_root, Default::default()))
+    }
+}
+
+#[cfg(feature = "optimism")]
+impl StateRootProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
     fn state_root(&self, _state: HashedPostState) -> ProviderResult<B256> {
         Ok(self.state_roots.lock().pop().unwrap_or_default())
     }
@@ -653,7 +1138,65 @@ impl StorageRootProvider for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl StorageRootProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn storage_root(
+        &self,
+        _address: Address,
+        _hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        Ok(EMPTY_ROOT_HASH)
+    }
+
+    fn storage_proof(
+        &self,
+        _address: Address,
+        slot: B256,
+        _hashed_storage: HashedStorage,
+    ) -> ProviderResult<reth_trie::StorageProof> {
+        Ok(StorageProof::new(slot))
+    }
+
+    fn storage_multiproof(
+        &self,
+        _address: Address,
+        _slots: &[B256],
+        _hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        Ok(StorageMultiProof::empty())
+    }
+}
+
+
 impl StateProofProvider for MockEthProvider {
+    fn proof(
+        &self,
+        _input: TrieInput,
+        address: Address,
+        _slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        Ok(AccountProof::new(address))
+    }
+
+    fn multiproof(
+        &self,
+        _input: TrieInput,
+        _targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        Ok(MultiProof::default())
+    }
+
+    fn witness(
+        &self,
+        _input: TrieInput,
+        _target: HashedPostState,
+    ) -> ProviderResult<B256HashMap<Bytes>> {
+        Ok(HashMap::default())
+    }
+}
+
+#[cfg(feature = "optimism")]
+impl StateProofProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
     fn proof(
         &self,
         _input: TrieInput,
@@ -686,7 +1229,39 @@ impl HashedPostStateProvider for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl HashedPostStateProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn hashed_post_state(&self, _state: &revm::db::BundleState) -> HashedPostState {
+        HashedPostState::default()
+    }
+}
+
+
 impl StateProvider for MockEthProvider {
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        let lock = self.accounts.lock();
+        Ok(lock.get(&account).and_then(|account| account.storage.get(&storage_key)).copied())
+    }
+
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        let lock = self.accounts.lock();
+        Ok(lock.values().find_map(|account| {
+            match (account.account.bytecode_hash.as_ref(), account.bytecode.as_ref()) {
+                (Some(bytecode_hash), Some(bytecode)) if bytecode_hash == code_hash => {
+                    Some(bytecode.clone())
+                }
+                _ => None,
+            }
+        }))
+    }
+}
+
+#[cfg(feature = "optimism")]
+impl StateProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
     fn storage(
         &self,
         account: Address,
@@ -761,6 +1336,60 @@ impl StateProviderFactory for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl StateProviderFactory for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn state_by_block_number_or_tag(
+        &self,
+        number_or_tag: BlockNumberOrTag,
+    ) -> ProviderResult<StateProviderBox> {
+        match number_or_tag {
+            BlockNumberOrTag::Latest => self.latest(),
+            BlockNumberOrTag::Finalized => {
+                // we can only get the finalized state by hash, not by num
+                let hash =
+                    self.finalized_block_hash()?.ok_or(ProviderError::FinalizedBlockNotFound)?;
+
+                // only look at historical state
+                self.history_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Safe => {
+                // we can only get the safe state by hash, not by num
+                let hash = self.safe_block_hash()?.ok_or(ProviderError::SafeBlockNotFound)?;
+
+                self.history_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Earliest => self.history_by_block_number(0),
+            BlockNumberOrTag::Pending => self.pending(),
+            BlockNumberOrTag::Number(num) => self.history_by_block_number(num),
+        }
+    }
+
+    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn pending(&self) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn pending_state_by_hash(&self, _block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
+        Ok(Some(Box::new(self.clone())))
+    }
+}
+
+
 impl WithdrawalsProvider for MockEthProvider {
     fn withdrawals_by_block(
         &self,
@@ -771,13 +1400,46 @@ impl WithdrawalsProvider for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl WithdrawalsProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn withdrawals_by_block(
+        &self,
+        _id: BlockHashOrNumber,
+        _timestamp: u64,
+    ) -> ProviderResult<Option<Withdrawals>> {
+        Ok(None)
+    }
+}
+
+
 impl OmmersProvider for MockEthProvider {
     fn ommers(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
         Ok(None)
     }
 }
 
+#[cfg(feature = "optimism")]
+impl OmmersProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn ommers(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
+        Ok(None)
+    }
+}
+
+
 impl BlockBodyIndicesProvider for MockEthProvider {
+    fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        Ok(None)
+    }
+    fn block_body_indices_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
+        Ok(vec![])
+    }
+}
+
+#[cfg(feature = "optimism")]
+impl BlockBodyIndicesProvider for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
     fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
         Ok(None)
     }
@@ -798,6 +1460,16 @@ impl ChangeSetReader for MockEthProvider {
     }
 }
 
+#[cfg(feature = "optimism")]
+impl ChangeSetReader for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    fn account_block_changeset(
+        &self,
+        _block_number: BlockNumber,
+    ) -> ProviderResult<Vec<AccountBeforeTx>> {
+        Ok(Vec::default())
+    }
+}
+
 impl StateReader for MockEthProvider {
     type Receipt = Receipt;
 
@@ -805,3 +1477,13 @@ impl StateReader for MockEthProvider {
         Ok(None)
     }
 }
+
+#[cfg(feature = "optimism")]
+impl StateReader for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
+    type Receipt = Receipt;
+
+    fn get_state(&self, _block: BlockNumber) -> ProviderResult<Option<ExecutionOutcome>> {
+        Ok(None)
+    }
+}
+

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -900,13 +900,15 @@ impl BlockReader for MockEthProvider<reth_optimism_primitives::OpTransactionSign
         }
     }
 
-    fn pending_block(&self) -> ProviderResult<Option<reth_primitives_traits::block::SealedBlock<Self::Block>>> {
+    fn pending_block(
+        &self,
+    ) -> ProviderResult<Option<reth_primitives_traits::block::SealedBlock<Self::Block>>> {
         Ok(None)
     }
 
     fn pending_block_with_senders(&self) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
-         Ok(None)
-     }
+        Ok(None)
+    }
 
     fn pending_block_and_receipts(&self) -> ProviderResult<Option<(reth_primitives_traits::block::SealedBlock<Self::Block>, Vec<Receipt>)>> {
         Ok(None)
@@ -952,7 +954,6 @@ impl BlockReader for MockEthProvider<reth_optimism_primitives::OpTransactionSign
         Ok(vec![])
     }
 }
-
 
 impl BlockReaderIdExt for MockEthProvider {
     fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Block>> {
@@ -1022,7 +1023,6 @@ impl AccountReader for MockEthProvider<reth_optimism_primitives::OpTransactionSi
     }
 }
 
-
 impl StageCheckpointReader for MockEthProvider {
     fn get_stage_checkpoint(&self, _id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
         Ok(None)
@@ -1051,7 +1051,6 @@ impl StageCheckpointReader for MockEthProvider<reth_optimism_primitives::OpTrans
         Ok(vec![])
     }
 }
-
 
 impl StateRootProvider for MockEthProvider {
     fn state_root(&self, _state: HashedPostState) -> ProviderResult<B256> {
@@ -1163,7 +1162,6 @@ impl StorageRootProvider for MockEthProvider<reth_optimism_primitives::OpTransac
     }
 }
 
-
 impl StateProofProvider for MockEthProvider {
     fn proof(
         &self,
@@ -1231,7 +1229,6 @@ impl HashedPostStateProvider for MockEthProvider<reth_optimism_primitives::OpTra
         HashedPostState::default()
     }
 }
-
 
 impl StateProvider for MockEthProvider {
     fn storage(
@@ -1385,7 +1382,6 @@ impl StateProviderFactory for MockEthProvider<reth_optimism_primitives::OpTransa
     }
 }
 
-
 impl WithdrawalsProvider for MockEthProvider {
     fn withdrawals_by_block(
         &self,
@@ -1407,7 +1403,6 @@ impl WithdrawalsProvider for MockEthProvider<reth_optimism_primitives::OpTransac
     }
 }
 
-
 impl OmmersProvider for MockEthProvider {
     fn ommers(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
         Ok(None)
@@ -1420,7 +1415,6 @@ impl OmmersProvider for MockEthProvider<reth_optimism_primitives::OpTransactionS
         Ok(None)
     }
 }
-
 
 impl BlockBodyIndicesProvider for MockEthProvider {
     fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
@@ -1482,4 +1476,3 @@ impl StateReader for MockEthProvider<reth_optimism_primitives::OpTransactionSign
         Ok(None)
     }
 }
-

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -910,7 +910,11 @@ impl BlockReader for MockEthProvider<reth_optimism_primitives::OpTransactionSign
         Ok(None)
     }
 
-    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(reth_primitives_traits::block::SealedBlock<Self::Block>, Vec<Receipt>)>> {
+    fn pending_block_and_receipts(
+        &self
+    ) -> ProviderResult<
+        Option<(reth_primitives_traits::block::SealedBlock<Self::Block>, Vec<Receipt>)>
+    > {
         Ok(None)
     }
 
@@ -984,7 +988,11 @@ impl BlockReaderIdExt for MockEthProvider {
 
 #[cfg(feature = "optimism")]
 impl BlockReaderIdExt for MockEthProvider<reth_optimism_primitives::OpTransactionSigned> {
-    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<alloy_consensus::Block<reth_optimism_primitives::OpTransactionSigned>>> {
+    fn block_by_id(
+        &self,
+        id: BlockId,
+    ) -> ProviderResult<Option<alloy_consensus::Block<reth_optimism_primitives::OpTransactionSigned>>>
+    {
         match id {
             BlockId::Number(num) => self.block_by_number_or_tag(num),
             BlockId::Hash(hash) => self.block_by_hash(hash.block_hash),

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -911,9 +911,9 @@ impl BlockReader for MockEthProvider<reth_optimism_primitives::OpTransactionSign
     }
 
     fn pending_block_and_receipts(
-        &self
+        &self,
     ) -> ProviderResult<
-        Option<(reth_primitives_traits::block::SealedBlock<Self::Block>, Vec<Receipt>)>
+        Option<(reth_primitives_traits::block::SealedBlock<Self::Block>, Vec<Receipt>)>,
     > {
         Ok(None)
     }

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -694,7 +694,7 @@ mod tests {
         let transactions_path = temp_dir.path().join(FILENAME).with_extension(EXTENSION);
         let tx_bytes = hex!("02f87201830655c2808505ef61f08482565f94388c818ca8b9251b393131c08a736a67ccb192978801049e39c4b5b1f580c001a01764ace353514e8abdfb92446de356b260e3c1225b73fc4c8876a6258d12a129a04f02294aa61ca7676061cd99f29275491218b4754b46a0248e5e42bc5091f507");
         let tx = PooledTransaction::decode_2718(&mut &tx_bytes[..]).unwrap();
-        let provider = MockEthProvider::default();
+        let provider = MockEthProvider::<TransactionSigned>::default();
         let transaction: EthPooledTransaction = tx.try_into_recovered().unwrap().into();
         let tx_to_cmp = transaction.clone();
         let sender = hex!("1f9090aaE28b8a3dCeaDf281B0F12828e676c326").into();

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -883,7 +883,7 @@ mod tests {
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{hex, U256};
     use reth_chainspec::MAINNET;
-    use reth_primitives::{transaction::SignedTransactionIntoRecoveredExt, PooledTransaction};
+    use reth_primitives::{TransactionSigned, transaction::SignedTransactionIntoRecoveredExt, PooledTransaction};
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 
     fn get_transaction() -> EthPooledTransaction {
@@ -909,7 +909,7 @@ mod tests {
         let res = ensure_intrinsic_gas(&transaction, &fork_tracker);
         assert!(res.is_ok());
 
-        let provider = MockEthProvider::default();
+        let provider = MockEthProvider::<TransactionSigned>::default();
         provider.add_account(
             transaction.sender(),
             ExtendedAccount::new(transaction.nonce(), U256::MAX),
@@ -936,7 +936,7 @@ mod tests {
     async fn invalid_on_gas_limit_too_high() {
         let transaction = get_transaction();
 
-        let provider = MockEthProvider::default();
+        let provider = MockEthProvider::<TransactionSigned>::default();
         provider.add_account(
             transaction.sender(),
             ExtendedAccount::new(transaction.nonce(), U256::MAX),

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -883,7 +883,9 @@ mod tests {
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{hex, U256};
     use reth_chainspec::MAINNET;
-    use reth_primitives::{TransactionSigned, transaction::SignedTransactionIntoRecoveredExt, PooledTransaction};
+    use reth_primitives::{
+        transaction::SignedTransactionIntoRecoveredExt, PooledTransaction, TransactionSigned,
+    };
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 
     fn get_transaction() -> EthPooledTransaction {


### PR DESCRIPTION
### Description

Fixes node tests in the transaction pool using the updated `OpTransactionSigned`. This requires implementing traits on the `MockEthProvider` with the concrete generic instead of the default `T = TransactionSigned` generic.

Closes #45 