### PR TITLE
Set withdrawals root in genesis header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8279,9 +8279,11 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-optimism-forks",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
  "serde_json",
  "thiserror 2.0.9",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -20,6 +20,7 @@ reth-network-peers.workspace = true
 
 # op-reth
 reth-optimism-forks.workspace = true
+reth-optimism-primitives.workspace = true
 
 # ethereum
 alloy-chains.workspace = true
@@ -39,6 +40,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 derive_more.workspace = true
 once_cell.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 reth-chainspec = { workspace = true, features = ["test-utils"] }

--- a/crates/optimism/chainspec/src/base.rs
+++ b/crates/optimism/chainspec/src/base.rs
@@ -12,25 +12,23 @@ use crate::{LazyLock, OpChainSpec};
 
 /// The Base mainnet spec
 pub static BASE_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
-    OpChainSpec {
-        inner: ChainSpec {
-            chain: Chain::base_mainnet(),
-            genesis: serde_json::from_str(include_str!("../res/genesis/base.json"))
-                .expect("Can't deserialize Base genesis json"),
-            genesis_hash: once_cell_set(b256!(
-                "f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"
-            )),
-            paris_block_and_final_difficulty: Some((0, U256::from(0))),
-            hardforks: OpHardfork::base_mainnet(),
-            base_fee_params: BaseFeeParamsKind::Variable(
-                vec![
-                    (EthereumHardfork::London.boxed(), BaseFeeParams::optimism()),
-                    (OpHardfork::Canyon.boxed(), BaseFeeParams::optimism_canyon()),
-                ]
-                .into(),
-            ),
-            ..Default::default()
-        },
-    }
+    OpChainSpec::from(ChainSpec {
+        chain: Chain::base_mainnet(),
+        genesis: serde_json::from_str(include_str!("../res/genesis/base.json"))
+            .expect("Can't deserialize Base genesis json"),
+        genesis_hash: once_cell_set(b256!(
+            "f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"
+        )),
+        paris_block_and_final_difficulty: Some((0, U256::from(0))),
+        hardforks: OpHardfork::base_mainnet(),
+        base_fee_params: BaseFeeParamsKind::Variable(
+            vec![
+                (EthereumHardfork::London.boxed(), BaseFeeParams::optimism()),
+                (OpHardfork::Canyon.boxed(), BaseFeeParams::optimism_canyon()),
+            ]
+            .into(),
+        ),
+        ..Default::default()
+    })
     .into()
 });

--- a/crates/optimism/chainspec/src/base_sepolia.rs
+++ b/crates/optimism/chainspec/src/base_sepolia.rs
@@ -12,26 +12,24 @@ use crate::{LazyLock, OpChainSpec};
 
 /// The Base Sepolia spec
 pub static BASE_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
-    OpChainSpec {
-        inner: ChainSpec {
-            chain: Chain::base_sepolia(),
-            genesis: serde_json::from_str(include_str!("../res/genesis/sepolia_base.json"))
-                .expect("Can't deserialize Base Sepolia genesis json"),
-            genesis_hash: once_cell_set(b256!(
-                "0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"
-            )),
-            paris_block_and_final_difficulty: Some((0, U256::from(0))),
-            hardforks: OpHardfork::base_sepolia(),
-            base_fee_params: BaseFeeParamsKind::Variable(
-                vec![
-                    (EthereumHardfork::London.boxed(), BaseFeeParams::base_sepolia()),
-                    (OpHardfork::Canyon.boxed(), BaseFeeParams::base_sepolia_canyon()),
-                ]
-                .into(),
-            ),
-            prune_delete_limit: 10000,
-            ..Default::default()
-        },
-    }
+    OpChainSpec::from(ChainSpec {
+        chain: Chain::base_sepolia(),
+        genesis: serde_json::from_str(include_str!("../res/genesis/sepolia_base.json"))
+            .expect("Can't deserialize Base Sepolia genesis json"),
+        genesis_hash: once_cell_set(b256!(
+            "0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"
+        )),
+        paris_block_and_final_difficulty: Some((0, U256::from(0))),
+        hardforks: OpHardfork::base_sepolia(),
+        base_fee_params: BaseFeeParamsKind::Variable(
+            vec![
+                (EthereumHardfork::London.boxed(), BaseFeeParams::base_sepolia()),
+                (OpHardfork::Canyon.boxed(), BaseFeeParams::base_sepolia_canyon()),
+            ]
+            .into(),
+        ),
+        prune_delete_limit: 10000,
+        ..Default::default()
+    })
     .into()
 });

--- a/crates/optimism/chainspec/src/dev.rs
+++ b/crates/optimism/chainspec/src/dev.rs
@@ -15,18 +15,16 @@ use crate::{LazyLock, OpChainSpec};
 /// Includes 20 prefunded accounts with `10_000` ETH each derived from mnemonic "test test test test
 /// test test test test test test test junk".
 pub static OP_DEV: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
-    OpChainSpec {
-        inner: ChainSpec {
-            chain: Chain::dev(),
-            genesis: serde_json::from_str(include_str!("../res/genesis/dev.json"))
-                .expect("Can't deserialize Dev testnet genesis json"),
-            genesis_hash: once_cell_set(DEV_GENESIS_HASH),
-            paris_block_and_final_difficulty: Some((0, U256::from(0))),
-            hardforks: DEV_HARDFORKS.clone(),
-            base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
-            deposit_contract: None, // TODO: do we even have?
-            ..Default::default()
-        },
-    }
+    OpChainSpec::from(ChainSpec {
+        chain: Chain::dev(),
+        genesis: serde_json::from_str(include_str!("../res/genesis/dev.json"))
+            .expect("Can't deserialize Dev testnet genesis json"),
+        genesis_hash: once_cell_set(DEV_GENESIS_HASH),
+        paris_block_and_final_difficulty: Some((0, U256::from(0))),
+        hardforks: DEV_HARDFORKS.clone(),
+        base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
+        deposit_contract: None, // TODO: do we even have?
+        ..Default::default()
+    })
     .into()
 });

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -241,6 +241,11 @@ impl OpChainSpec {
             ))
         }
     }
+
+    /// Destructs into inner [`ChainSpec`].
+    pub fn clone_inner(&self) -> ChainSpec {
+        self.inner.clone()
+    }
 }
 
 impl EthChainSpec for OpChainSpec {

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -180,7 +180,13 @@ impl OpChainSpecBuilder {
     /// This function panics if the chain ID and genesis is not set ([`Self::chain`] and
     /// [`Self::genesis`])
     pub fn build(self) -> OpChainSpec {
-        OpChainSpec::from(self.inner.build())
+        let inner = self.inner.build();
+        if inner.is_optimism_mainnet() {
+            // for OP mainnet we have to do this because the genesis header can't be properly
+            // computed from the genesis.json file
+            let _ = inner.genesis_hash.set(OP_MAINNET.genesis_hash());
+        }
+        OpChainSpec::from(inner)
     }
 }
 
@@ -612,9 +618,6 @@ mod tests {
     #[test]
     fn op_mainnet_forkids() {
         let op_mainnet = OpChainSpecBuilder::optimism_mainnet().build();
-        // for OP mainnet we have to do this because the genesis header can't be properly computed
-        // from the genesis.json file
-        let _ = op_mainnet.genesis_hash.set(OP_MAINNET.genesis_hash());
         test_fork_ids(
             &op_mainnet,
             &[

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -1069,18 +1069,16 @@ mod tests {
     fn holocene_chainspec() -> Arc<OpChainSpec> {
         let mut hardforks = OpHardfork::base_sepolia();
         hardforks.insert(OpHardfork::Holocene.boxed(), ForkCondition::Timestamp(1800000000));
-        Arc::new(OpChainSpec {
-            inner: ChainSpec {
-                chain: BASE_SEPOLIA.chain,
-                genesis: BASE_SEPOLIA.genesis.clone(),
-                genesis_hash: BASE_SEPOLIA.genesis_hash.clone(),
-                paris_block_and_final_difficulty: Some((0, U256::from(0))),
-                hardforks,
-                base_fee_params: BASE_SEPOLIA.base_fee_params.clone(),
-                prune_delete_limit: 10000,
-                ..Default::default()
-            },
-        })
+        Arc::new(OpChainSpec::from(ChainSpec {
+            chain: BASE_SEPOLIA.chain,
+            genesis: BASE_SEPOLIA.genesis.clone(),
+            genesis_hash: BASE_SEPOLIA.genesis_hash.clone(),
+            paris_block_and_final_difficulty: Some((0, U256::from(0))),
+            hardforks,
+            base_fee_params: BASE_SEPOLIA.base_fee_params.clone(),
+            prune_delete_limit: 10000,
+            ..Default::default()
+        }))
     }
 
     #[test]

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -424,9 +424,9 @@ impl From<Genesis> for OpChainSpec {
 impl From<ChainSpec> for OpChainSpec {
     fn from(mut inner: ChainSpec) -> Self {
         // under the hood makes header, if not yet init
-        _ = inner.genesis_header();
+        let header = inner.genesis_header();
         // fill once lock with a value, if not yet init
-        _ = inner.genesis_hash.get_or_init(Default::default);
+        _ = inner.genesis_hash.get_or_init(|| header.hash_slow());
 
         if inner.hardforks.is_fork_active_at_timestamp(OpHardfork::Isthmus, inner.genesis.timestamp)
         {
@@ -733,6 +733,7 @@ mod tests {
     #[test]
     fn latest_base_mainnet_fork_id_with_builder() {
         let base_mainnet = OpChainSpecBuilder::base_mainnet().build();
+        assert_eq!(OpHardfork::Isthmus.fork_id(), base_mainnet.latest_fork_id());
         assert_eq!(
             ForkId { hash: ForkHash([0x3a, 0x2a, 0xf1, 0x83]), next: 0 },
             base_mainnet.latest_fork_id()

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -1071,12 +1071,12 @@ mod tests {
         hardforks.insert(OpHardfork::Holocene.boxed(), ForkCondition::Timestamp(1800000000));
         Arc::new(OpChainSpec {
             inner: ChainSpec {
-                chain: BASE_SEPOLIA.inner.chain,
-                genesis: BASE_SEPOLIA.inner.genesis.clone(),
-                genesis_hash: BASE_SEPOLIA.inner.genesis_hash.clone(),
+                chain: BASE_SEPOLIA.chain,
+                genesis: BASE_SEPOLIA.genesis.clone(),
+                genesis_hash: BASE_SEPOLIA.genesis_hash.clone(),
                 paris_block_and_final_difficulty: Some((0, U256::from(0))),
                 hardforks,
-                base_fee_params: BASE_SEPOLIA.inner.base_fee_params.clone(),
+                base_fee_params: BASE_SEPOLIA.base_fee_params.clone(),
                 prune_delete_limit: 10000,
                 ..Default::default()
             },

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -733,7 +733,6 @@ mod tests {
     #[test]
     fn latest_base_mainnet_fork_id_with_builder() {
         let base_mainnet = OpChainSpecBuilder::base_mainnet().build();
-        assert_eq!(OpHardfork::Isthmus.fork_id(), base_mainnet.latest_fork_id());
         assert_eq!(
             ForkId { hash: ForkHash([0x3a, 0x2a, 0xf1, 0x83]), next: 0 },
             base_mainnet.latest_fork_id()

--- a/crates/optimism/chainspec/src/op.rs
+++ b/crates/optimism/chainspec/src/op.rs
@@ -10,28 +10,26 @@ use reth_optimism_forks::OpHardfork;
 
 /// The Optimism Mainnet spec
 pub static OP_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
-    OpChainSpec {
-        inner: ChainSpec {
-            chain: Chain::optimism_mainnet(),
-            // genesis contains empty alloc field because state at first bedrock block is imported
-            // manually from trusted source
-            genesis: serde_json::from_str(include_str!("../res/genesis/optimism.json"))
-                .expect("Can't deserialize Optimism Mainnet genesis json"),
-            genesis_hash: once_cell_set(b256!(
-                "7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"
-            )),
-            paris_block_and_final_difficulty: Some((0, U256::from(0))),
-            hardforks: OpHardfork::op_mainnet(),
-            base_fee_params: BaseFeeParamsKind::Variable(
-                vec![
-                    (EthereumHardfork::London.boxed(), BaseFeeParams::optimism()),
-                    (OpHardfork::Canyon.boxed(), BaseFeeParams::optimism_canyon()),
-                ]
-                .into(),
-            ),
-            prune_delete_limit: 10000,
-            ..Default::default()
-        },
-    }
+    OpChainSpec::from(ChainSpec {
+        chain: Chain::optimism_mainnet(),
+        // genesis contains empty alloc field because state at first bedrock block is imported
+        // manually from trusted source
+        genesis: serde_json::from_str(include_str!("../res/genesis/optimism.json"))
+            .expect("Can't deserialize Optimism Mainnet genesis json"),
+        genesis_hash: once_cell_set(b256!(
+            "7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"
+        )),
+        paris_block_and_final_difficulty: Some((0, U256::from(0))),
+        hardforks: OpHardfork::op_mainnet(),
+        base_fee_params: BaseFeeParamsKind::Variable(
+            vec![
+                (EthereumHardfork::London.boxed(), BaseFeeParams::optimism()),
+                (OpHardfork::Canyon.boxed(), BaseFeeParams::optimism_canyon()),
+            ]
+            .into(),
+        ),
+        prune_delete_limit: 10000,
+        ..Default::default()
+    })
     .into()
 });

--- a/crates/optimism/chainspec/src/op_sepolia.rs
+++ b/crates/optimism/chainspec/src/op_sepolia.rs
@@ -10,26 +10,24 @@ use reth_optimism_forks::OpHardfork;
 
 /// The OP Sepolia spec
 pub static OP_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
-    OpChainSpec {
-        inner: ChainSpec {
-            chain: Chain::from_named(NamedChain::OptimismSepolia),
-            genesis: serde_json::from_str(include_str!("../res/genesis/sepolia_op.json"))
-                .expect("Can't deserialize OP Sepolia genesis json"),
-            genesis_hash: once_cell_set(b256!(
-                "102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"
-            )),
-            paris_block_and_final_difficulty: Some((0, U256::from(0))),
-            hardforks: OpHardfork::op_sepolia(),
-            base_fee_params: BaseFeeParamsKind::Variable(
-                vec![
-                    (EthereumHardfork::London.boxed(), BaseFeeParams::optimism_sepolia()),
-                    (OpHardfork::Canyon.boxed(), BaseFeeParams::optimism_sepolia_canyon()),
-                ]
-                .into(),
-            ),
-            prune_delete_limit: 10000,
-            ..Default::default()
-        },
-    }
+    OpChainSpec::from(ChainSpec {
+        chain: Chain::from_named(NamedChain::OptimismSepolia),
+        genesis: serde_json::from_str(include_str!("../res/genesis/sepolia_op.json"))
+            .expect("Can't deserialize OP Sepolia genesis json"),
+        genesis_hash: once_cell_set(b256!(
+            "102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"
+        )),
+        paris_block_and_final_difficulty: Some((0, U256::from(0))),
+        hardforks: OpHardfork::op_sepolia(),
+        base_fee_params: BaseFeeParamsKind::Variable(
+            vec![
+                (EthereumHardfork::London.boxed(), BaseFeeParams::optimism_sepolia()),
+                (OpHardfork::Canyon.boxed(), BaseFeeParams::optimism_sepolia_canyon()),
+            ]
+            .into(),
+        ),
+        prune_delete_limit: 10000,
+        ..Default::default()
+    })
     .into()
 });

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -238,7 +238,7 @@ mod tests {
         // Use the `OpEvmConfig` to create the `cfg_env` and `block_env` based on the ChainSpec,
         // Header, and total difficulty
         let EvmEnv { cfg_env_with_handler_cfg, .. } =
-            OpEvmConfig::new(Arc::new(OpChainSpec { inner: chain_spec.clone() }))
+            OpEvmConfig::new(Arc::new(OpChainSpec::from(chain_spec.clone())))
                 .cfg_and_block_env(&header);
 
         // Assert that the chain ID in the `cfg_env` is correctly set to the chain ID of the

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -216,7 +216,7 @@ mod test {
         let hardforks = OpHardfork::base_sepolia();
         Arc::new(OpChainSpec {
             inner: ChainSpec {
-                chain: BASE_SEPOLIA.inner.chain,
+                chain: BASE_SEPOLIA.chain,
                 genesis: BASE_SEPOLIA.inner.genesis.clone(),
                 genesis_hash: BASE_SEPOLIA.inner.genesis_hash.clone(),
                 paris_block_and_final_difficulty: BASE_SEPOLIA

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -214,18 +214,16 @@ mod test {
 
     fn get_chainspec() -> Arc<OpChainSpec> {
         let hardforks = OpHardfork::base_sepolia();
-        Arc::new(OpChainSpec {
-            inner: ChainSpec {
-                chain: BASE_SEPOLIA.chain,
-                genesis: BASE_SEPOLIA.genesis.clone(),
-                genesis_hash: BASE_SEPOLIA.genesis_hash.clone(),
-                paris_block_and_final_difficulty: BASE_SEPOLIA.paris_block_and_final_difficulty,
-                hardforks,
-                base_fee_params: BASE_SEPOLIA.base_fee_params.clone(),
-                prune_delete_limit: 10000,
-                ..Default::default()
-            },
-        })
+        Arc::new(OpChainSpec::from(ChainSpec {
+            chain: BASE_SEPOLIA.chain,
+            genesis: BASE_SEPOLIA.genesis.clone(),
+            genesis_hash: BASE_SEPOLIA.genesis_hash.clone(),
+            paris_block_and_final_difficulty: BASE_SEPOLIA.paris_block_and_final_difficulty,
+            hardforks,
+            base_fee_params: BASE_SEPOLIA.base_fee_params.clone(),
+            prune_delete_limit: 10000,
+            ..Default::default()
+        }))
     }
 
     const fn get_attributes(eip_1559_params: Option<B64>, timestamp: u64) -> OpPayloadAttributes {

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -217,13 +217,13 @@ mod test {
         Arc::new(OpChainSpec {
             inner: ChainSpec {
                 chain: BASE_SEPOLIA.chain,
-                genesis: BASE_SEPOLIA.inner.genesis.clone(),
-                genesis_hash: BASE_SEPOLIA.inner.genesis_hash.clone(),
+                genesis: BASE_SEPOLIA.genesis.clone(),
+                genesis_hash: BASE_SEPOLIA.genesis_hash.clone(),
                 paris_block_and_final_difficulty: BASE_SEPOLIA
                     .inner
                     .paris_block_and_final_difficulty,
                 hardforks,
-                base_fee_params: BASE_SEPOLIA.inner.base_fee_params.clone(),
+                base_fee_params: BASE_SEPOLIA.base_fee_params.clone(),
                 prune_delete_limit: 10000,
                 ..Default::default()
             },

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -219,9 +219,7 @@ mod test {
                 chain: BASE_SEPOLIA.chain,
                 genesis: BASE_SEPOLIA.genesis.clone(),
                 genesis_hash: BASE_SEPOLIA.genesis_hash.clone(),
-                paris_block_and_final_difficulty: BASE_SEPOLIA
-                    .inner
-                    .paris_block_and_final_difficulty,
+                paris_block_and_final_difficulty: BASE_SEPOLIA.paris_block_and_final_difficulty,
                 hardforks,
                 base_fee_params: BASE_SEPOLIA.base_fee_params.clone(),
                 prune_delete_limit: 10000,

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -355,7 +355,7 @@ where
         let blob_store = DiskFileBlobStore::open(data_dir.blobstore(), Default::default())?;
 
         let validator = TransactionValidationTaskExecutor::eth_builder(Arc::new(
-            ctx.chain_spec().inner.clone(),
+            ctx.chain_spec().clone_inner(),
         ))
         .no_eip4844()
         .with_head_timestamp(ctx.head().timestamp)

--- a/crates/optimism/primitives/src/lib.rs
+++ b/crates/optimism/primitives/src/lib.rs
@@ -12,9 +12,11 @@
 extern crate alloc;
 
 pub mod bedrock;
-pub mod transaction;
 
-use reth_primitives_traits::Block;
+pub mod predeploys;
+pub use predeploys::ADDRESS_L2_TO_L1_MESSAGE_PASSER;
+
+pub mod transaction;
 pub use transaction::{signed::OpTransactionSigned, tx_type::OpTxType};
 
 mod receipt;
@@ -40,3 +42,4 @@ impl reth_primitives_traits::NodePrimitives for OpPrimitives {
 }
 
 use once_cell as _;
+use reth_primitives_traits::Block;

--- a/crates/optimism/primitives/src/predeploys.rs
+++ b/crates/optimism/primitives/src/predeploys.rs
@@ -1,0 +1,8 @@
+//! Addresses of OP pre-deploys.
+// todo: move to op-alloy
+
+use alloy_primitives::{address, Address};
+
+/// The L2 contract `L2ToL1MessagePasser`, stores commitments to withdrawal transactions.
+pub const ADDRESS_L2_TO_L1_MESSAGE_PASSER: Address =
+    address!("4200000000000000000000000000000000000016");


### PR DESCRIPTION
- Sets withdrawals root in genesis header upon construction of `OpChainSpec`
- Restricts visibility of inner `ChainSpec` type to private, to ensure safe construction of `OpChainSpec` always updates the header and genesis header hash