### PR TITLE
chore(ci): Fix op-reth image in kurtosis params

### DIFF
--- a/.github/assets/kurtosis_op_network_params_remote.yaml
+++ b/.github/assets/kurtosis_op_network_params_remote.yaml
@@ -12,7 +12,7 @@ optimism_package:
         cl_extra_params:
           - "--l1.trustrpc=true"
       - el_type: op-reth
-        el_image: "op-reth:latest"
+        el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"
         cl_type: op-node
         cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop
         cl_extra_params:


### PR DESCRIPTION
Fixes op-reth image in kurtosis params for workflow that is using op-node and op-geth from registry