### PR TITLE
chore: Clean up the kurtosis actions

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -3,14 +3,15 @@ description: Install everything we need to run the CI pipelines
 runs:
   using: "composite"
   steps:
-    # Install foundry
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
 
-    # Install kurtosis
-    - name: Run kurtosis
+    - name: Install kurtosis
       shell: bash
       run: |
         echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
         sudo apt update
         sudo apt install kurtosis-cli
+
+    - name: Start kurtosis engine
+      run: kurtosis engine start

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,16 @@
+name: Setup test environment
+description: Install everything we need to run the CI pipelines
+runs:
+  using: "composite"
+  steps:
+    # Install foundry
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+
+    # Install kurtosis
+    - name: Run kurtosis
+      shell: bash
+      run: |
+        echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+        sudo apt update
+        sudo apt install kurtosis-cli

--- a/.github/workflows/kurtosis-op-local.yml
+++ b/.github/workflows/kurtosis-op-local.yml
@@ -103,7 +103,6 @@ jobs:
 
       - name: Run kurtosis
         run: |
-          kurtosis engine start
           kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params_local.yaml
           ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
           GETH_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-1-op-geth-op-node-op-kurtosis".public_ports.rpc.number')
@@ -160,7 +159,6 @@ jobs:
 
       - name: Run kurtosis
         run: |
-          kurtosis engine start
           kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params_local_no_op_geth.yaml
           ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
           RETH_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-1-op-reth-op-node-op-kurtosis".public_ports.rpc.number')

--- a/.github/workflows/kurtosis-op-local.yml
+++ b/.github/workflows/kurtosis-op-local.yml
@@ -81,6 +81,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
       - name: Download docker image artifacts
         uses: actions/download-artifact@v4
         with:
@@ -98,14 +101,8 @@ jobs:
           # List available images
           docker image ls -a
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
       - name: Run kurtosis
         run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
           kurtosis engine start
           kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params_local.yaml
           ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
@@ -142,6 +139,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
       - name: Download docker image artifacts
         uses: actions/download-artifact@v4
         with:
@@ -158,14 +158,8 @@ jobs:
           # List available images
           docker image ls -a
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
       - name: Run kurtosis
         run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
           kurtosis engine start
           kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params_local_no_op_geth.yaml
           ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')

--- a/.github/workflows/kurtosis-op-remote.yml
+++ b/.github/workflows/kurtosis-op-remote.yml
@@ -55,7 +55,6 @@ jobs:
 
       - name: Run kurtosis
         run: |
-          kurtosis engine start
           kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params_remote.yaml
           ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
           GETH_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-1-op-geth-op-node-op-kurtosis".public_ports.rpc.number')
@@ -110,7 +109,6 @@ jobs:
 
       - name: Run kurtosis
         run: |
-          kurtosis engine start
           kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params_remote_no_op_geth.yaml
           ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
           RETH_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-1-op-reth-op-node-op-kurtosis".public_ports.rpc.number')

--- a/.github/workflows/kurtosis-op-remote.yml
+++ b/.github/workflows/kurtosis-op-remote.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
       - name: Download docker image artifacts
         uses: actions/download-artifact@v4
         with:
@@ -50,14 +53,8 @@ jobs:
           # List available images
           docker image ls -a
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
       - name: Run kurtosis
         run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
           kurtosis engine start
           kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params_remote.yaml
           ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
@@ -93,6 +90,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
       - name: Download docker image artifacts
         uses: actions/download-artifact@v4
         with:
@@ -108,14 +108,8 @@ jobs:
           # List available images
           docker image ls -a
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
       - name: Run kurtosis
         run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
           kurtosis engine start
           kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params_remote_no_op_geth.yaml
           ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')


### PR DESCRIPTION
### In this PR

- Create a reusable action that sets up the CI environment before we add complexity to the kurtosis workflows
- Example run [here](https://github.com/ethereum-optimism/op-reth/actions/runs/13042197861)