### PR TITLE
fix: Missing shell property on an action

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -14,4 +14,5 @@ runs:
         sudo apt install kurtosis-cli
 
     - name: Start kurtosis engine
+      shell: bash
       run: kurtosis engine start


### PR DESCRIPTION
### In this PR

Adds a missing `shell` property on a local composite action